### PR TITLE
add cuda-samples tests

### DIFF
--- a/active_checks/active_checks.dockerfile
+++ b/active_checks/active_checks.dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     echo "Using architecture: $ARCH_DEB" && \
     wget -P /tmp "${PACKAGES_REPO_URL}/nccl_tests_${CUDA_VERSION}_ubuntu24.04/nccl-tests-perf-${ARCH_DEB}.tar.gz" && \
     tar -xvzf /tmp/nccl-tests-perf-${ARCH_DEB}.tar.gz -C /usr/bin && \
-    rm -rf /tmp/nccl-tests-perf-${ARCH_DEB}.tar.gz
+    rm -rf /tmp/nccl-tests-perf-${ARCH_DEB}.tar.gz && \
+    wget -P /tmp "${PACKAGES_REPO_URL}/cuda_samples_${CUDA_VERSION}_ubuntu24.04/cuda-samples-${ARCH_DEB}.tar.gz" && \
+    tar -xvzf /tmp/cuda-samples-${ARCH_DEB}.tar.gz -C /usr/bin --strip-components=1 && \
+    rm -rf /tmp/cuda-samples-${ARCH_DEB}.tar.gz


### PR DESCRIPTION
```
srun --gpus-per-node=8 --container-image=cr.eu-north1.nebius.cloud#soperator/active_checks:12.9.0-ubuntu24.04-nccl_tests2.16.4-a90ddfe-amd --container-mounts=/root/health-checker:/usr/bin/health-checker /usr/bin/health-checker run -e soperator -p 8xH100 -n deviceQuery,vectorAdd,simpleMultiGPU,p2pBandwidthLatencyTest --log-level info -f mk8s-txt
cpu-bind=MASK - worker-0, task  0  0 [2493545]: mask 0xffff000000000000ffff set
R: Empty, S: PASS
```