### PR TITLE
SCHED-1197: Ship latest NCCL with Inspector plugin and Inspector PreConf for Slurm

### DIFF
--- a/.github/workflows/training_diag.yml
+++ b/.github/workflows/training_diag.yml
@@ -41,7 +41,7 @@ jobs:
             runner: ubuntu-24.04-arm
             nvidia_require_cuda: "cuda>=12.9 brand=unknown,driver>=535,driver<536 brand=grid,driver>=535,driver<536 brand=tesla,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=vapps,driver>=535,driver<536 brand=vpc,driver>=535,driver<536 brand=vcs,driver>=535,driver<536 brand=vws,driver>=535,driver<536 brand=cloudgaming,driver>=535,driver<536 brand=unknown,driver>=550,driver<551 brand=grid,driver>=550,driver<551 brand=tesla,driver>=550,driver<551 brand=nvidia,driver>=550,driver<551 brand=quadro,driver>=550,driver<551 brand=quadrortx,driver>=550,driver<551 brand=nvidiartx,driver>=550,driver<551 brand=vapps,driver>=550,driver<551 brand=vpc,driver>=550,driver<551 brand=vcs,driver>=550,driver<551 brand=vws,driver>=550,driver<551 brand=cloudgaming,driver>=550,driver<551 brand=unknown,driver>=560,driver<561 brand=grid,driver>=560,driver<561 brand=tesla,driver>=560,driver<561 brand=nvidia,driver>=560,driver<561 brand=quadro,driver>=560,driver<561 brand=quadrortx,driver>=560,driver<561 brand=nvidiartx,driver>=560,driver<561 brand=vapps,driver>=560,driver<561 brand=vpc,driver>=560,driver<561 brand=vcs,driver>=560,driver<561 brand=vws,driver>=560,driver<561 brand=cloudgaming,driver>=560,driver<561 brand=unknown,driver>=565,driver<566 brand=grid,driver>=565,driver<566 brand=tesla,driver>=565,driver<566 brand=nvidia,driver>=565,driver<566 brand=quadro,driver>=565,driver<566 brand=quadrortx,driver>=565,driver<566 brand=nvidiartx,driver>=565,driver<566 brand=vapps,driver>=565,driver<566 brand=vpc,driver>=565,driver<566 brand=vcs,driver>=565,driver<566 brand=vws,driver>=565,driver<566 brand=cloudgaming,driver>=565,driver<566 brand=unknown,driver>=570,driver<571 brand=grid,driver>=570,driver<571 brand=tesla,driver>=570,driver<571 brand=nvidia,driver>=570,driver<571 brand=quadro,driver>=570,driver<571 brand=quadrortx,driver>=570,driver<571 brand=nvidiartx,driver>=570,driver<571 brand=vapps,driver>=570,driver<571 brand=vpc,driver>=570,driver<571 brand=vcs,driver>=570,driver<571 brand=vws,driver>=570,driver<571 brand=cloudgaming,driver>=570,driver<571"
 
-          # CUDA 13 + NCCL tests 2.17.6
+          # CUDA 13 + NCCL tests 2.17.9
           - name: training_diag-cuda13
             cuda_version: "13.0.2"
             ubuntu_version: "ubuntu24.04"
@@ -97,10 +97,11 @@ jobs:
           set -euo pipefail
           IMAGE="${IMAGE_BASE}:${{ matrix.cuda_version }}-${{ matrix.ubuntu_version }}-${DAYTIME}"
           ARCH_TAG="${IMAGE}-${{ matrix.arch }}"
-          
           CACHE_REF="${IMAGE_BASE}:${{ matrix.cuda_version }}-${{ matrix.ubuntu_version }}-${{ matrix.arch }}"
 
           echo "Pushing: ${ARCH_TAG} (${{ matrix.platform }}) with cache ${CACHE_REF}"
+          echo "  CUDA_VERSION=${{ matrix.cuda_version }}"
+          echo "  NCCL_TESTS_VERSION=${{ matrix.nccl_tests_version }}"
 
           docker buildx build \
             --platform "${{ matrix.platform }}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,6 +219,16 @@ FROM training AS training_diag
 # Image for training and diagnostics with a specific tools
 ######
 
+ARG CUDA_VERSION
+ENV CUDA_VERSION=$CUDA_VERSION
+
+# Install NCCL Inspector profiler plugin
+COPY ansible/nccl-inspector.yml /opt/ansible/nccl-inspector.yml
+COPY ansible/roles/nccl-inspector /opt/ansible/roles/nccl-inspector
+RUN cd /opt/ansible && \
+    ansible-playbook -i inventory/ -c local nccl-inspector.yml \
+    -e "nccl_inspector_cuda_version=${CUDA_VERSION}"
+
 # Install dcgmi tools
 # https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/dcgm-diagnostics.html
 COPY ansible/dcgmi.yml /opt/ansible/dcgmi.yml

--- a/ansible/nccl-inspector.yml
+++ b/ansible/nccl-inspector.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Install NCCL Inspector
+  hosts:
+    - all
+    - localhost
+  gather_facts: true
+  gather_subset:
+    - min
+  become: true
+  roles:
+    - nccl-inspector
+  tags:
+    - nccl-inspector

--- a/ansible/roles/cuda/defaults/main.yml
+++ b/ansible/roles/cuda/defaults/main.yml
@@ -7,16 +7,16 @@ cuda_packages:
     - "libcudnn9-cuda-12=9.10.1.4-1"
     - "libcudnn9-dev-cuda-12=9.10.1.4-1"
     - "libcudnn9-headers-cuda-12=9.10.1.4-1"
-    - "libnccl-dev=2.26.5-1+cuda12.9"
-    - "libnccl2=2.26.5-1+cuda12.9"
+    - "libnccl-dev=2.30.3-1+cuda12.9"
+    - "libnccl2=2.30.3-1+cuda12.9"
   "13.0.2":
     - "cuda=13.0.2-1"
     - "libcublas-dev-13-0=13.1.1.3-1"
     - "libcudnn9-cuda-13=9.15.0.58-1"
     - "libcudnn9-dev-cuda-13=9.15.0.58-1"
     - "libcudnn9-headers-cuda-13=9.15.0.58-1"
-    - "libnccl-dev=2.30.1-1+cuda13.0~custom1"
-    - "libnccl2=2.30.1-1+cuda13.0~custom1"
+    - "libnccl-dev=2.30.4-1+cuda13.0"
+    - "libnccl2=2.30.4-1+cuda13.0"
 
 cuda_hold_packages:
   "12.9.0":
@@ -67,11 +67,11 @@ cuda_pin_content:
     Pin-Priority: 1001
 
     Package: libnccl-dev
-    Pin: version 2.26.5-1+cuda12.9
+    Pin: version 2.30.3-1+cuda12.9
     Pin-Priority: 1001
 
     Package: libnccl2
-    Pin: version 2.26.5-1+cuda12.9
+    Pin: version 2.30.3-1+cuda12.9
     Pin-Priority: 1001
 
   "13.0.2": |
@@ -104,11 +104,11 @@ cuda_pin_content:
     Pin-Priority: 1001
 
     Package: libnccl-dev
-    Pin: version 2.30.1-1+cuda13.0~custom1
+    Pin: version 2.30.4-1+cuda13.0
     Pin-Priority: 1001
 
     Package: libnccl2
-    Pin: version 2.30.1-1+cuda13.0~custom1
+    Pin: version 2.30.4-1+cuda13.0
     Pin-Priority: 1001
 
 cuda_dpkg_arch_map:

--- a/ansible/roles/cuda/defaults/main.yml
+++ b/ansible/roles/cuda/defaults/main.yml
@@ -88,7 +88,7 @@ cuda_pin_content:
     Pin-Priority: 1001
 
     Package: libcublas-dev-13-0
-    Pin: version 13.1.0.3-1
+    Pin: version 13.1.1.3-1
     Pin-Priority: 1001
 
     Package: libcudnn9-cuda-13

--- a/ansible/roles/nccl-inspector/defaults/main.yml
+++ b/ansible/roles/nccl-inspector/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+
+nccl_inspector_package_map:
+  "12.9.0":
+    package_version: "2.30.3-1+cuda12.9-1"
+    nccl_version: "2.30.3-1+cuda12.9"
+  "13.0.2":
+    package_version: "2.30.4-1+cuda13.0-1"
+    nccl_version: "2.30.4-1+cuda13.0"
+
+nccl_inspector_pin_path: /etc/apt/preferences.d/nccl-inspector-pins
+nccl_inspector_hold_packages:
+  - libnccl-profiler-inspector

--- a/ansible/roles/nccl-inspector/tasks/main.yml
+++ b/ansible/roles/nccl-inspector/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+
+- name: Assert nccl_inspector_cuda_version is supported
+  ansible.builtin.assert:
+    that:
+      - nccl_inspector_cuda_version is defined
+      - nccl_inspector_package_map[nccl_inspector_cuda_version] is defined
+    fail_msg: >-
+      Unsupported or missing nccl_inspector_cuda_version '{{ nccl_inspector_cuda_version | default('') }}'.
+      Available: {{ nccl_inspector_package_map.keys() | list | join(', ') }}
+  tags:
+    - nccl-inspector
+
+- name: Set NCCL Inspector package facts
+  ansible.builtin.set_fact:
+    nccl_inspector_package_version: "{{ nccl_inspector_package_map[nccl_inspector_cuda_version].package_version }}"
+    nccl_inspector_required_nccl_version: "{{ nccl_inspector_package_map[nccl_inspector_cuda_version].nccl_version }}"
+  tags:
+    - nccl-inspector
+
+- name: Query installed NCCL runtime version
+  ansible.builtin.command: "dpkg-query -W -f=${Version} libnccl2"
+  register: nccl_inspector_libnccl2_query
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  tags:
+    - nccl-inspector
+
+- name: Assert installed NCCL runtime matches NCCL Inspector
+  ansible.builtin.assert:
+    that:
+      - nccl_inspector_libnccl2_query.rc == 0
+      - nccl_inspector_libnccl2_query.stdout == nccl_inspector_required_nccl_version
+    fail_msg: >-
+      NCCL Inspector {{ nccl_inspector_package_version }} requires libnccl2
+      {{ nccl_inspector_required_nccl_version }}, but installed libnccl2 is
+      {{ nccl_inspector_libnccl2_query.stdout | default('missing') }}.
+  tags:
+    - nccl-inspector
+
+- name: Pin NCCL Inspector package
+  ansible.builtin.copy:
+    dest: "{{ nccl_inspector_pin_path }}"
+    content: |
+      Package: libnccl-profiler-inspector
+      Pin: version {{ nccl_inspector_package_version }}
+      Pin-Priority: 1001
+    owner: root
+    group: root
+    mode: "0644"
+  tags:
+    - nccl-inspector
+
+- name: Install NCCL Inspector package
+  ansible.builtin.apt:
+    name: "libnccl-profiler-inspector={{ nccl_inspector_package_version }}"
+    state: present
+    update_cache: true
+  tags:
+    - nccl-inspector
+
+- name: Hold NCCL Inspector package
+  ansible.builtin.dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop: "{{ nccl_inspector_hold_packages }}"
+  loop_control:
+    label: "{{ item }}"
+  tags:
+    - nccl-inspector


### PR DESCRIPTION
## What has been done

- NCCL versions are bumped:
  - CUDA 12: `2.26.5-1+cuda12.9` -> `2.30.3-1+cuda12.9`
  - CUDA 13: `2.30.1-1+cuda13.0~custom1` -> `2.30.4-1+cuda13.0`
- Role for `nccl-inspector` is added to Ansible and is being installed into `training-diag` image

## Notes

### Images built

| Name | Workflow | TS |
| :--- | :--- | :---: |
| Ansible roles | https://github.com/nebius/ml-containers/actions/runs/27278732044 | `20260610131236` |
| `training_diag` | https://github.com/nebius/ml-containers/actions/runs/27278724346 | `20260610131231` |
| `slurm_training_diag` | https://github.com/nebius/ml-containers/actions/runs/27278714436 | `20260610131219` |

### Tickets to cover

- [Ensure Soperator provides latest NCCL with Inspector plugin available](https://nebius.atlassian.net/browse/SCHED-1197)
  - [Establish a deployment process for NCCL Inspector plugin](https://nebius.atlassian.net/browse/SCHED-1344)
